### PR TITLE
make blockservice AddBlocks return more quickly

### DIFF
--- a/blockservice.go
+++ b/blockservice.go
@@ -181,6 +181,10 @@ func (s *blockService) AddBlocks(bs []blocks.Block) error {
 		toput = bs
 	}
 
+	if len(toput) == 0 {
+		return nil
+	}
+
 	err := s.blockstore.PutMany(toput)
 	if err != nil {
 		return err


### PR DESCRIPTION
if there is no new blocks, just return rather than calling `blockstore.PutMany` method.