### PR TITLE
feat(session): instantiated sessions lazily

### DIFF
--- a/blockservice.go
+++ b/blockservice.go
@@ -114,9 +114,8 @@ func (s *blockService) Exchange() exchange.Interface {
 func NewSession(ctx context.Context, bs BlockService) *Session {
 	exch := bs.Exchange()
 	if sessEx, ok := exch.(exchange.SessionExchange); ok {
-		ses := sessEx.NewSession(ctx)
 		return &Session{
-			ses:    ses,
+			ses:    nil,
 			sessEx: sessEx,
 			bs:     bs.Blockstore(),
 		}


### PR DESCRIPTION
Do not instantiate a bitswap session if all operations are local

fix https://github.com/ipfs/go-ipfs/issues/4660